### PR TITLE
update: KeyLaunchの宣伝を追加

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -13,7 +13,9 @@ hero:
 import { LinkCard, CardGrid, FileTree, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 <Aside type='note'>
-  このページは99%ぐらいは完成していますが、100%完成ではないです。
+  `KeyLaunch`というChrome拡張機能を開発しました！ <br />
+  ぜひ、[こちら](https://github.com/twil3akine/keylaunch)から使ってみてください！！ <br />
+  バグ等の報告は`issue`からお願いいたします！
 </Aside>
 
 ## こんにちは！ 私は `Twil3akine` です👍


### PR DESCRIPTION
- KeyLaunchのv1.0.0をリリースしたので、ランディングページのトップに追加