### PR TITLE
Google検索向けのSEO設定を追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,12 +2,13 @@
 import { defineConfig } from "astro/config";
 import { fileURLToPath } from "node:url";
 import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
 import svelte from "@astrojs/svelte";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 
 export default defineConfig({
-  site: "https://twil3akine.pages.dev",
+  site: "https://twil3akine.org",
   trailingSlash: "always",
   prefetch: {
     prefetchAll: true,
@@ -21,6 +22,7 @@ export default defineConfig({
     },
   },
   integrations: [
+    sitemap(),
     mdx({
       remarkPlugins: [remarkMath],
       rehypePlugins: [rehypeKatex],

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "mylogs",
       "dependencies": {
         "@astrojs/mdx": "^6.0.3",
+        "@astrojs/sitemap": "^3.7.3",
         "@astrojs/svelte": "^8.1.2",
         "astro": "6.4.5",
         "katex": "^0.16.22",
@@ -29,6 +30,8 @@
     "@astrojs/mdx": ["@astrojs/mdx@6.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "0.3.0", "astro": "^6.4.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
 
     "@astrojs/svelte": ["@astrojs/svelte@8.1.2", "", { "dependencies": { "@sveltejs/vite-plugin-svelte": "^6.2.4", "svelte2tsx": "^0.7.55", "vite": "^7.3.2", "vitefu": "^1.1.2" }, "peerDependencies": { "astro": "^6.0.0", "svelte": "^5.43.6", "typescript": "^5.3.3 || ^6.0.0" } }, "sha512-L4eBoTY+DdgyH1g8pmKJxidRSvdk+NbkyJt5+f8EtdyJtPdxogeCyG3eEDmlIqqXxzNqLg7k/tYCjfBQ4kDMRA=="],
 
@@ -258,6 +261,10 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
+    "@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
+
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -269,6 +276,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -720,6 +729,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -727,6 +738,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -761,6 +774,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "@astrojs/mdx": "^6.0.3",
+    "@astrojs/sitemap": "^3.7.3",
     "@astrojs/svelte": "^8.1.2",
     "astro": "6.4.5",
     "katex": "^0.16.22",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://twil3akine.org/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ interface Props {
 const {
   title,
   description,
-  image = "/ogp.png",
+  image,
   lang = "ja",
   type = "website",
   articleDate,
@@ -44,6 +44,7 @@ const fallbackDescription = fallbackDescriptions[lang];
 const pageDescription = description || frontmatter?.description || fallbackDescription;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site || Astro.url.origin);
+const absoluteImageURL = new URL(image ?? "/ogp.png", canonicalURL);
 const alternatePath = alternatePathProp === undefined
   ? getAlternateLocalePath(Astro.url.pathname, lang)
   : alternatePathProp;
@@ -53,6 +54,54 @@ const alternateURL = alternatePath
 const showLanguageLink = shouldShowLanguageSwitch(lang) && alternatePath !== null;
 
 const siteTitle = "Twil3akine";
+const siteURL = new URL("/", Astro.site || Astro.url.origin);
+const author = {
+  "@type": "Person",
+  name: siteTitle,
+  url: siteURL,
+  sameAs: [
+    "https://github.com/twil3akine",
+    "https://twitter.com/twil3akine",
+    "https://atcoder.jp/users/twil3",
+  ],
+};
+const website = {
+  "@type": "WebSite",
+  name: siteTitle,
+  url: siteURL,
+  inLanguage: ["ja", "en"],
+  author,
+};
+const isHomePage = Astro.url.pathname === "/" || Astro.url.pathname === "/en/";
+const structuredData = type === "article"
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: pageTitle.replace(/ \| Twil3akine$/, ""),
+      description: pageDescription,
+      url: canonicalURL,
+      mainEntityOfPage: canonicalURL,
+      inLanguage: lang,
+      datePublished: articleDate,
+      author,
+      publisher: author,
+      ...(image ? { image: absoluteImageURL } : {}),
+    }
+  : isHomePage ? {
+      "@context": "https://schema.org",
+      ...website,
+      description: pageDescription,
+    }
+  : {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: pageTitle,
+      description: pageDescription,
+      url: canonicalURL,
+      inLanguage: lang,
+      isPartOf: website,
+    };
+const structuredDataJSON = JSON.stringify(structuredData).replace(/</g, "\\u003c");
 const localePrefix = getLocalePrefix(lang);
 const navLinks = [
   { href: `${localePrefix}/profile/`, label: "Profile" },
@@ -68,7 +117,9 @@ const navLinks = [
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{pageTitle}</title>
     <meta name="description" content={pageDescription} />
+    <meta name="robots" content="index, follow" />
     <link rel="canonical" href={canonicalURL} />
+    <link rel="alternate" hreflang={lang} href={canonicalURL} />
     {showLanguageLink && alternateURL && <link rel="alternate" hreflang={lang === "en" ? "ja" : "en"} href={alternateURL} />}
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -82,7 +133,7 @@ const navLinks = [
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={pageDescription} />
-    {image && <meta property="og:image" content={new URL(image, canonicalURL)} />}
+    <meta property="og:image" content={absoluteImageURL} />
 
     <!-- Article Specific -->
     {type === 'article' && articleDate && <meta property="article:published_time" content={articleDate} />}
@@ -92,7 +143,9 @@ const navLinks = [
     <meta property="twitter:url" content={canonicalURL} />
     <meta property="twitter:title" content={pageTitle} />
     <meta property="twitter:description" content={pageDescription} />
-    {image && <meta property="twitter:image" content={new URL(image, canonicalURL)} />}
+    <meta property="twitter:image" content={absoluteImageURL} />
+
+    <script type="application/ld+json" set:html={structuredDataJSON} />
 
     <ClientRouter />
 


### PR DESCRIPTION
## 変更内容

- canonical URLとOGP URLの基準を独自ドメイン `twil3akine.org` に統一
- `@astrojs/sitemap`で全公開ページのサイトマップを生成
- `robots.txt`からサイトマップを案内
- 日本語・英語ページに自己参照を含む`hreflang`を追加
- WebSite、WebPage、BlogPostingのJSON-LD構造化データを追加
- 記事固有画像がある場合だけBlogPostingの代表画像として出力

## 目的

Googleなどの検索エンジンが公開ページの正規URL、言語違い、記事情報を正しくクロール・解釈できる状態にするためです。

## 影響

- サイトの見た目や既存ページのURLは変わりません。
- canonical URLはCloudflare Pagesのサブドメインから独自ドメインへ変わります。
- ビルド時に`sitemap-index.xml`と`sitemap-0.xml`が生成されます。

## 確認

- `bun install --frozen-lockfile`
- `bun run build`
- `xmllint --noout dist/sitemap-index.xml dist/sitemap-0.xml`
- クリーンなコミット内容だけで16ページを再ビルド
- 全16ページのcanonical、robots meta、JSON-LD、サイトマップ収録を自動検証
- `https://twil3akine.org/`がHTTP 200を返すことを確認
