### PR TITLE
Adjust mobile layout width

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -65,4 +65,11 @@ const currentYear = new Date().getFullYear();
   .footer-actions :global(a:hover) {
     color: var(--theme-accent);
   }
+
+  @media (max-width: 640px) {
+    .footer-inner {
+      padding-right: 1rem;
+      padding-left: 1rem;
+    }
+  }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -145,6 +145,11 @@ const { siteTitle = "", navLinks = [] } = Astro.props;
   }
 
   @media (max-width: 576px) {
+    .header-inner {
+      padding-right: 1rem;
+      padding-left: 1rem;
+    }
+
     .menu-toggle {
       position: absolute;
       display: block;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -177,6 +177,14 @@ const navLinks = [
         font-weight: 700;
         text-decoration: none;
       }
+
+      @media (max-width: 640px) {
+        .layout-container {
+          padding-right: 1rem;
+          padding-left: 1rem;
+          gap: 0;
+        }
+      }
     </style>
 
     <script is:inline>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -70,6 +70,13 @@ main {
   padding: 0rem 1.5rem;
 }
 
+@media (max-width: 640px) {
+  main {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary
- Reduce horizontal layout padding on mobile widths so content can use more of the viewport.
- Remove the extra `main` side padding on small screens.
- Align header and footer mobile side padding with the main layout.

## Impact
This improves readability on narrow smartphone viewports without changing the desktop layout or page-specific max widths.

## Validation
- `bun run build`

Note: the build completed successfully. Existing LinkCard fetch warnings appeared for external URLs during static generation.