### PR TITLE
Add works page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -84,7 +84,7 @@ const { siteTitle = "", navLinks = [] } = Astro.props;
     align-items: center;
     min-height: 4rem;
     width: 100%;
-    padding: 0.75rem 2rem;
+    padding: 0.75rem clamp(1rem, 4vw, 2rem);
   }
   .header-left {
     display: flex;
@@ -144,12 +144,7 @@ const { siteTitle = "", navLinks = [] } = Astro.props;
     display: none;
   }
 
-  @media (max-width: 576px) {
-    .header-inner {
-      padding-right: 1rem;
-      padding-left: 1rem;
-    }
-
+  @media (max-width: 640px) {
     .menu-toggle {
       position: absolute;
       display: block;
@@ -190,6 +185,7 @@ const { siteTitle = "", navLinks = [] } = Astro.props;
       top: calc(100% + 1px);
       left: 0;
       right: 0;
+      box-sizing: border-box;
       display: none;
       flex-direction: column;
       align-items: stretch;

--- a/src/components/ProfileLanding.astro
+++ b/src/components/ProfileLanding.astro
@@ -97,7 +97,7 @@ const profile = profileLanding[locale];
     </div>
   </aside>
 
-  <div class="landing-side" aria-label="Content">
+  <div class="landing-side" aria-label="Content" style={`--section-count: ${profile.sections.length}`}>
     {
       profile.sections.map((section, index) => (
         <a class="content-link" href={section.href}>
@@ -167,7 +167,7 @@ const profile = profileLanding[locale];
   .landing-side {
     display: grid;
     align-content: stretch;
-    grid-template-rows: repeat(3, 1fr);
+    grid-template-rows: repeat(var(--section-count), 1fr);
     max-width: 640px;
     min-height: 100%;
     border-left: 1px solid var(--theme-border);
@@ -178,7 +178,7 @@ const profile = profileLanding[locale];
     display: flex;
     align-items: center;
     gap: 1.1rem;
-    min-height: 8.25rem;
+    min-height: 6.35rem;
     border-bottom: 1px solid var(--theme-border);
     color: var(--theme-text);
     text-decoration: none;
@@ -378,7 +378,7 @@ const profile = profileLanding[locale];
     }
 
     .content-link {
-      min-height: 6.25rem;
+      min-height: 5.75rem;
     }
 
     .content-link strong {

--- a/src/components/WorksPage.astro
+++ b/src/components/WorksPage.astro
@@ -1,0 +1,249 @@
+---
+import { worksContent } from "@/data/works";
+import type { Locale } from "@/data/locales";
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = "ja" } = Astro.props;
+const content = worksContent[locale];
+const visitLabel = locale === "ja" ? "見る" : "Visit";
+const sourceLabel = locale === "ja" ? "Source" : "Source";
+---
+
+<section class="works-page">
+  <header class="works-header">
+    <h1>{content.title}</h1>
+    <p>{content.lead}</p>
+  </header>
+
+  {
+    content.sections.map((section) => (
+      <section class="works-section" aria-labelledby={`works-${section.title}`}>
+        <div class="section-heading">
+          <h2 id={`works-${section.title}`}>{section.title}</h2>
+          <p>{section.description}</p>
+        </div>
+
+        <div class="work-list">
+          {
+            section.items.map((item) => (
+              <article class:list={["work-card", item.featured && "work-card-featured"]}>
+                <div class="work-meta">
+                  <span>{item.period}</span>
+                  <span>{item.category}</span>
+                </div>
+
+                <h3>
+                  <a href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} rel={item.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                    {item.title}
+                  </a>
+                </h3>
+
+                <p>{item.description}</p>
+
+                <div class="work-links">
+                  <a href={item.href} target={item.href.startsWith("http") ? "_blank" : undefined} rel={item.href.startsWith("http") ? "noopener noreferrer" : undefined}>
+                    {visitLabel}
+                  </a>
+                  {
+                    item.sourceHref && (
+                      <a href={item.sourceHref} target="_blank" rel="noopener noreferrer">
+                        {sourceLabel}
+                      </a>
+                    )
+                  }
+                </div>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+    ))
+  }
+</section>
+
+<style>
+  .works-page {
+    width: min(100%, 1040px);
+    margin: 0 auto;
+    padding: clamp(2.5rem, 7vw, 5rem) 0;
+  }
+
+  :global(main.main-content) {
+    max-width: none;
+    width: 100%;
+  }
+
+  .works-header {
+    margin-bottom: 3rem;
+  }
+
+  .works-header h1 {
+    margin: 0;
+    font-size: var(--font-size-page-title);
+    line-height: 1.05;
+  }
+
+  .works-header p,
+  .section-heading p {
+    margin: 1.2rem 0 0;
+    color: color-mix(in srgb, var(--theme-text), transparent 22%);
+    font-size: var(--font-size-body-large);
+    line-height: 1.9;
+  }
+
+  .works-section {
+    display: grid;
+    grid-template-columns: minmax(10rem, 15rem) minmax(0, 1fr);
+    gap: clamp(2rem, 4vw, 3rem);
+    padding: 0 0 2.5rem;
+    border-bottom: 1px solid var(--theme-border);
+  }
+
+  .works-section + .works-section {
+    padding-top: 2.5rem;
+  }
+
+  .works-section:last-child {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .section-heading {
+    position: sticky;
+    top: 5.5rem;
+    align-self: start;
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    font-size: var(--font-size-section-title);
+    line-height: 1.25;
+  }
+
+  .section-heading p {
+    font-size: var(--font-size-body);
+    line-height: 1.75;
+  }
+
+  .work-list {
+    display: grid;
+    gap: 0;
+    border-top: 1px solid var(--theme-border);
+  }
+
+  .work-card {
+    display: grid;
+    gap: 0.8rem;
+    padding: 1.55rem 0 1.65rem;
+    border-bottom: 1px solid var(--theme-border);
+  }
+
+  .work-card:last-child {
+    border-bottom: 0;
+  }
+
+  .work-card-featured h3::after {
+    content: "Featured";
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.35rem;
+    margin-left: 0.65rem;
+    padding: 0 0.55rem;
+    border: 1px solid color-mix(in srgb, var(--theme-accent), transparent 45%);
+    border-radius: 999px;
+    background: var(--theme-accent-bg);
+    color: var(--theme-accent);
+    font-size: 0.76rem;
+    font-weight: 800;
+    line-height: 1;
+    vertical-align: middle;
+  }
+
+  .work-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    color: color-mix(in srgb, var(--theme-text), transparent 45%);
+    font-family: var(--theme-font-mono);
+    font-size: 0.86rem;
+    font-weight: 700;
+  }
+
+  .work-meta span + span::before {
+    content: "/";
+    margin-right: 0.55rem;
+    color: color-mix(in srgb, var(--theme-text), transparent 65%);
+  }
+
+  .work-card h3 {
+    margin: 0;
+    font-size: var(--font-size-card-title);
+    line-height: 1.35;
+  }
+
+  .work-card h3 a {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .work-card h3 a:hover {
+    color: var(--theme-accent);
+  }
+
+  .work-card p {
+    max-width: 46rem;
+    margin: 0;
+    color: color-mix(in srgb, var(--theme-text), transparent 20%);
+    line-height: 1.8;
+  }
+
+  .work-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .work-links a {
+    color: var(--theme-accent);
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .work-links a:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  @media (max-width: 760px) {
+    .works-page {
+      padding: 2rem 0 3rem;
+    }
+
+    .works-header {
+      margin-bottom: 2.25rem;
+    }
+
+    .works-section {
+      display: block;
+      padding: 0 0 2rem;
+    }
+
+    .works-section + .works-section {
+      padding-top: 2rem;
+    }
+
+    .section-heading {
+      position: static;
+      margin-bottom: 1.35rem;
+    }
+
+    .work-links {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/src/content/profile/index.en.mdx
+++ b/src/content/profile/index.en.mdx
@@ -30,7 +30,7 @@ When I feel like I am lacking my daily dose of competitive programming, I also j
 To be honest, while I appreciate that international contests start late, isn't it a bit tough that they also end so late...?
 
 ↓ Profile URLs
-<LinkCard href="https://atcoder.jp/users/twil3akine" />
+<LinkCard href="https://atcoder.jp/users/twil3" />
 <LinkCard href="https://codeforces.com/profile/Twil3akine" />
 <LinkCard href="https://repovive.com/users/6a2a1cb82f298ea9148fee52" />
 <LinkCard href="https://profiles.topcoder.com/Twil3akine" />

--- a/src/content/profile/index.ja.mdx
+++ b/src/content/profile/index.ja.mdx
@@ -30,7 +30,7 @@ import Marker from "@/components/Marker.astro";
 正直、海外コンテストって開始時間遅いから助かるけど、開示時間遅いからちょっと辛くないですか...？
 
 ↓ 各サイトのURL
-<LinkCard href="https://atcoder.jp/users/twil3akine" />
+<LinkCard href="https://atcoder.jp/users/twil3" />
 <LinkCard href="https://codeforces.com/profile/Twil3akine" />
 <LinkCard href="https://repovive.com/users/6a2a1cb82f298ea9148fee52" />
 <LinkCard href="https://profiles.topcoder.com/Twil3akine" />

--- a/src/data/profileLanding.ts
+++ b/src/data/profileLanding.ts
@@ -39,6 +39,12 @@ export const profileLanding = {
         href: "/profile/",
       },
       {
+        label: "Works",
+        title: "作ったもの",
+        description: "個人開発、公開サービス、競プロまわりの活動をまとめてます。",
+        href: "/works/",
+      },
+      {
         label: "Article",
         title: "技術記事",
         description: "競プロ、開発、学んだことをあとから読める形で残します。",
@@ -68,6 +74,12 @@ export const profileLanding = {
         title: "About me",
         description: "A short overview of my affiliation, interests, and tools I use.",
         href: "/en/profile/",
+      },
+      {
+        label: "Works",
+        title: "Projects",
+        description: "Projects, public services, and competitive programming activities.",
+        href: "/en/works/",
       },
       {
         label: "Article",

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -1,0 +1,223 @@
+import type { Locale } from "./locales";
+
+interface WorkItem {
+  title: string;
+  description: string;
+  href: string;
+  sourceHref?: string;
+  period: string;
+  category: string;
+  featured?: boolean;
+}
+
+interface WorkSection {
+  title: string;
+  description: string;
+  items: WorkItem[];
+}
+
+interface WorksContent {
+  title: string;
+  description: string;
+  lead: string;
+  sections: WorkSection[];
+}
+
+export const worksContent = {
+  ja: {
+    title: "Works",
+    description: "公開している制作物、活動、競技プログラミングまわりの実績をまとめています。",
+    lead: "作ったもの、運営しているもの、競プロでやってきたことをあとから見返せる形で残します。",
+    sections: [
+      {
+        title: "制作物",
+        description: "Web、デスクトップアプリ、Rust製ツールなど。表に出せるものから順に置いています。",
+        items: [
+          {
+            title: "AtCoder Random Picker",
+            description:
+              "AtCoderの問題をDiff範囲で絞り、ランダムに提示する精進支援サービスです。RustのバックエンドとSvelteのフロントエンドで作っています。",
+            href: "https://rp.twil3akine.org",
+            sourceHref: "https://github.com/Twil3akine/atcoder-random-picker",
+            period: "2025 -",
+            category: "Web Service",
+            featured: true,
+          },
+          {
+            title: "Ravin Theme",
+            description:
+              "ブログ、ドキュメント、ポートフォリオ向けのAstro/Svelteテーマです。MDXコンポーネント、検索、ダークモード、SEO周りをひと通り揃えています。",
+            href: "http://ravin-theme.pages.dev",
+            sourceHref: "https://github.com/Twil3akine/Ravin",
+            period: "2026",
+            category: "Theme",
+            featured: true,
+          },
+          {
+            title: "MyLogs",
+            description:
+              "このサイトです。プロフィール、技術記事、日々のログを置くためにAstroで作り直しました。競プロ、開発、学んだことをあとから読める形で残します。",
+            href: "https://twil3akine.org",
+            sourceHref: "https://github.com/Twil3akine/MyLogs",
+            period: "2024 -",
+            category: "Portfolio",
+          },
+        ],
+      },
+      {
+        title: "活動",
+        description: "競技プログラミングと、その周辺で続けていることです。",
+        items: [
+          {
+            title: "WCPC",
+            description:
+              "和歌山大学公認競技プログラミングサークルです。2024年12月から活動しており、AtCoderやオンサイトコンテストへの参加を中心に動いています。",
+            href: "https://wcpc.pages.dev",
+            period: "2024 -",
+            category: "Community",
+            featured: true,
+          },
+          {
+            title: "AtCoder Heuristic",
+            description:
+              "短期より長期、アルゴリズムよりヒューリスティックが好きです。2026年7月時点でHeuristic Ratingは1600台に乗っています。",
+            href: "https://atcoder.jp/users/twil3?contestType=heuristic",
+            sourceHref: "https://github.com/Twil3akine/AtCoder-Heu",
+            period: "2024 -",
+            category: "Contest",
+          },
+          {
+            title: "ICPC 2026 国内予選",
+            description:
+              "チームWaSanBonで参加しました。悔しさごと記事に残しているので、来年に向けて見返せるログです。",
+            href: "/article/icpc2026/",
+            period: "2026",
+            category: "Contest",
+          },
+        ],
+      },
+      {
+        title: "Rust crates / CLI",
+        description: "小さめですが、crates.ioまで出しているものです。",
+        items: [
+          {
+            title: "sakd",
+            description:
+              "Rustで作ったタスク管理CLIです。毎日の作業を雑に投げ込むだけではなく、依存関係や順番を意識して整理できるように試しています。",
+            href: "https://crates.io/crates/sakd",
+            sourceHref: "https://github.com/Twil3akine/sakd",
+            period: "2026",
+            category: "CLI",
+          },
+          {
+            title: "gut-cli",
+            description:
+              "gitのタイプミスに反応する小さなRust CLIです。勢いで作ったものですが、crates.ioに公開しています。",
+            href: "https://crates.io/crates/gut-cli",
+            sourceHref: "https://github.com/Twil3akine/gut-cli",
+            period: "2026",
+            category: "CLI",
+          },
+        ],
+      },
+    ],
+  },
+  en: {
+    title: "Works",
+    description: "A collection of projects, activities, and competitive programming work I can show publicly.",
+    lead: "Projects I built, communities I run, and competitive programming logs worth keeping in one place.",
+    sections: [
+      {
+        title: "Projects",
+        description: "Web apps, desktop tools, and Rust projects that are public enough to point people to.",
+        items: [
+          {
+            title: "AtCoder Random Picker",
+            description:
+              "A practice helper that randomly picks AtCoder problems from a selected difficulty range. It uses a Rust backend and a Svelte frontend.",
+            href: "https://rp.twil3akine.org",
+            sourceHref: "https://github.com/Twil3akine/atcoder-random-picker",
+            period: "2025 -",
+            category: "Web Service",
+            featured: true,
+          },
+          {
+            title: "Ravin Theme",
+            description:
+              "An Astro/Svelte theme for blogs, documentation, and portfolios, with MDX components, search, dark mode, and SEO support.",
+            href: "http://ravin-theme.pages.dev",
+            sourceHref: "https://github.com/Twil3akine/Ravin",
+            period: "2026",
+            category: "Theme",
+            featured: true,
+          },
+          {
+            title: "MyLogs",
+            description:
+              "This site. I rebuilt it with Astro to keep my profile, technical articles, and daily logs readable over time.",
+            href: "https://twil3akine.org",
+            sourceHref: "https://github.com/Twil3akine/MyLogs",
+            period: "2024 -",
+            category: "Portfolio",
+          },
+        ],
+      },
+      {
+        title: "Activities",
+        description: "Competitive programming and the surrounding things I keep doing.",
+        items: [
+          {
+            title: "WCPC",
+            description:
+              "An official competitive programming circle at Wakayama University. It started in December 2024 and focuses on AtCoder and onsite contests.",
+            href: "https://wcpc.pages.dev",
+            period: "2024 -",
+            category: "Community",
+            featured: true,
+          },
+          {
+            title: "AtCoder Heuristic",
+            description:
+              "I prefer long-form heuristic contests over short algorithm rounds. As of July 2026, my Heuristic Rating is in the 1600 range.",
+            href: "https://atcoder.jp/users/twil3?contestType=heuristic",
+            sourceHref: "https://github.com/Twil3akine/AtCoder-Heu",
+            period: "2024 -",
+            category: "Contest",
+          },
+          {
+            title: "ICPC 2026 Domestic Qualifiers",
+            description:
+              "I participated as part of team WaSanBon and kept the result and regrets as a log for next year.",
+            href: "/en/article/icpc2026/",
+            period: "2026",
+            category: "Contest",
+          },
+        ],
+      },
+      {
+        title: "Rust crates / CLI",
+        description: "Small projects, but they are published on crates.io.",
+        items: [
+          {
+            title: "sakd",
+            description:
+              "A Rust task-management CLI for organizing daily work with a little more structure than a plain memo, including dependencies and ordering.",
+            href: "https://crates.io/crates/sakd",
+            sourceHref: "https://github.com/Twil3akine/sakd",
+            period: "2026",
+            category: "CLI",
+          },
+          {
+            title: "gut-cli",
+            description:
+              "A tiny Rust CLI that reacts to git typos. It is a small joke project, but it is published on crates.io.",
+            href: "https://crates.io/crates/gut-cli",
+            sourceHref: "https://github.com/Twil3akine/gut-cli",
+            period: "2026",
+            category: "CLI",
+          },
+        ],
+      },
+    ],
+  },
+} satisfies Record<Locale, WorksContent>;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -105,6 +105,7 @@ const structuredDataJSON = JSON.stringify(structuredData).replace(/</g, "\\u003c
 const localePrefix = getLocalePrefix(lang);
 const navLinks = [
   { href: `${localePrefix}/profile/`, label: "Profile" },
+  { href: `${localePrefix}/works/`, label: "Works" },
   { href: `${localePrefix}/article/`, label: "Article" },
   { href: `${localePrefix}/blog/`, label: "Blog" },
 ];

--- a/src/pages/en/works.astro
+++ b/src/pages/en/works.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import WorksPage from "@/components/WorksPage.astro";
+import { worksContent } from "@/data/works";
+
+const content = worksContent.en;
+---
+
+<Layout title={`${content.title} | Twil3akine`} description={content.description} lang="en">
+  <WorksPage locale="en" />
+</Layout>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "@/layouts/Layout.astro";
+import WorksPage from "@/components/WorksPage.astro";
+import { worksContent } from "@/data/works";
+
+const content = worksContent.ja;
+---
+
+<Layout title={`${content.title} | Twil3akine`} description={content.description} lang="ja">
+  <WorksPage locale="ja" />
+</Layout>


### PR DESCRIPTION
## Summary
- Add localized Works content data and a Works page for Japanese and English routes.
- Expose Works from the landing page and header navigation.
- Adjust the landing list and mobile header breakpoint for the added nav item.
- Fix Profile AtCoder links from `twil3akine` to `twil3`.

## Impact
Visitors can now browse public projects, activities, and small Rust tools from a dedicated Works page. Existing Profile links now point to the active AtCoder profile.

## Validation
- `bun run build`

Note: the build completed successfully. Existing LinkCard fetch warnings appeared for external URLs during static generation.